### PR TITLE
Process-to-container mapping support for CRIO and Docker runtime

### DIFF
--- a/pkg/gpumgr/process.go
+++ b/pkg/gpumgr/process.go
@@ -5,6 +5,7 @@ import (
 	"github.com/shirou/gopsutil/v3/process"
 	log "github.com/sirupsen/logrus"
 	"path/filepath"
+	"regexp"
 )
 
 type GpuProcess struct {
@@ -16,6 +17,8 @@ type GpuProcess struct {
 	User           string
 	ContainerId    string
 }
+
+var scopeContainerCgroupRe = regexp.MustCompile(`[^-]+-(.+)\.scope`)
 
 func (p *GpuProcess) SetProcessCmdline() {
 	if pr, err := process.NewProcess(int32(p.Pid)); err == nil {
@@ -66,6 +69,13 @@ func (p *GpuProcess) SetProcessContainerId() {
 				for _, c := range g.Controllers {
 					if c == "memory" {
 						p.ContainerId = filepath.Base(g.Path)
+						// Docker-based runtime container cgroup name is "docker-<ContainerId>.scope"
+						// CRIO runtime container cgroup name is "crio-<ContainerId>.scope"
+						// Containerd runtime container cgroup name is just "<ContainerId>"
+						scopeContainerMatch := scopeContainerCgroupRe.FindStringSubmatch(p.ContainerId)
+						for _, scopeContainerId := range scopeContainerMatch {
+							p.ContainerId = scopeContainerId
+						}
 						goto ExitContainerIdSet
 					}
 				}


### PR DESCRIPTION
Initial symptom, after deploying metaGPU, was no information about Pod processes.

After troubleshooting it is turned out the process-to-container mapping is not working. This comes down to the fact that "cgroup name equal to container id" is only true for containerd runtime.

Containers created by Docker or CRIO do have prefix and `.scope` suffix as well. 

This patch aims to recognize Docker/CRIO cgroup naming format and extract the ContianerId to make mapping happens.